### PR TITLE
Fix PyLint error `keyword-arg-before-vararg`

### DIFF
--- a/teamspeak_bot.py
+++ b/teamspeak_bot.py
@@ -172,6 +172,7 @@ class Ts3Bot:
 
     def __init__(
         self,
+        *_,
         host,
         port,
         serverid,
@@ -187,7 +188,6 @@ class Ts3Bot:
         sshloadsystemhostkeys="False",
         sshtimeout=None,
         sshtimeoutlimit=3,
-        *_,
         **__,
     ):
         """


### PR DESCRIPTION
See https://vald-phoenix.github.io/pylint-errors/plerr/errors/typecheck/W1113.html for further information.