### PR TITLE
Add support for multiple bad nickname regexes

### DIFF
--- a/modules/bad_nickname/README.md
+++ b/modules/bad_nickname/README.md
@@ -34,8 +34,15 @@ This plugin supports the following options:
 | `enable_dry_run` | `False` | Set to `True`, if you want to test the plugin without executing the actual tasks. Instead it logs what it would have done. |
 | `frequency` | `30.0` | The frequency in seconds how often (and fast) the plugin should react (e.g. somebody uses a not allowed nickname, every 30 seconds the bot would notice this and do something). |
 | `exclude_servergroups` | `None` | Provide a comma seperated list of servergroup names, which should never get kicked by the bot. |
-| `name_pattern` | `[a|4]dm[i|1]n` | A [regular expression](https://docs.python.org/3/library/re.html), which client nicknames are not allowed. (case insensitive) |
 | `kick_reason_message` | `Your client nickname is not allowed here!` | The kick reason message, which will be shown the respective kicked client. (Maximum supported length: 40 characters) |
+
+This plugin supports the following channel options:
+
+> **_NOTE:_** `<alias>` can be anything - it's only used to differentiate between multiple channel configurations. Supported characters for the `alias`: `a-z`, `A-Z`, `0-9_`
+
+| Option | Default | Description |
+| ---: | :---: | :--- |
+| `<alias>.name_pattern` | `None` | A [regular expression](https://docs.python.org/3/library/re.html), which client nicknames are not allowed. (case insensitive) |
 
 If you need to change some of these default options, simply add them to your `config.ini` under the respective `ModuleName` section:
 
@@ -43,8 +50,10 @@ If you need to change some of these default options, simply add them to your `co
 [bad_nickname]
 frequency: 10.0
 exclude_servergroups: Server Admin,Bot
-name_pattern: [a|4]dm[i|1]n[i|1][s|5][tr][a|4][t][o|0][r]?
 kick_reason_message: Please reconnect with a different nickname.
+
+admin.name_pattern: [a@4]dm[i!1]n
+administrator.name_pattern: [a|4]dm[i|1]n[i|1][s|5][tr][a|4][t][o|0][r]
 ```
 
 Please keep in mind, that you need to reload the plugin afterwards. Either by restarting the entire bot or by using a plugin command, if it has one.


### PR DESCRIPTION
This pull request also fixes the wrong implemented `kick_reason_message`, which was defined as `kick_message` in the code. Correct is now `kick_reason_message`.