### PR TITLE
Improve client setup error handling

### DIFF
--- a/teamspeak_bot.py
+++ b/teamspeak_bot.py
@@ -138,8 +138,16 @@ class Ts3Bot:
                     )
                 else:
                     raise query_exception
+
             try:
                 self.channel = self.get_channel_id(self.default_channel)
+            except TS3QueryException as query_exception:
+                self.logger.error(
+                    f"Failed to find the default channel `{str(self.default_channel)}`."
+                )
+                raise query_exception
+
+            try:
                 self.ts3conn.clientmove(
                     self.channel, int(self.ts3conn.whoami()["client_id"])
                 )
@@ -149,11 +157,17 @@ class Ts3Bot:
                         "The bot is already in the configured default channel"
                     )
                 else:
+                    self.logger.exception(
+                        f"Failed to move the bot to the default channel `{str(self.default_channel)}`."
+                    )
                     raise query_exception
+
         except TS3QueryException:
             self.logger.exception("Error on setting up client")
             self.ts3conn.quit()
+            self.ts3conn = None
             return
+
         self.command_handler = command_handler.CommandHandler(self.ts3conn)
         self.event_handler = event_handler.EventHandler(
             ts3conn=self.ts3conn, command_handler=self.command_handler


### PR DESCRIPTION
- Log a proper error message, that people without code knowledge understand the issue
- In case of client setup issues, properly disconnect and stop the bot to avoid additional exceptions.

Before:
```shell
(venv) root@6e1d21c4400e:/teamspeak3-python-bot# ./main.py
Error on setting up client
Traceback (most recent call last):
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 152, in setup_bot
    raise query_exception
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 142, in setup_bot
    self.channel = self.get_channel_id(self.default_channel)
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 55, in get_channel_id
    ret = self.ts3conn.channelfind(pattern=name)
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 440, in channelfind
    self._send("channelfind", ["pattern=" + pattern]))
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 167, in _send
    raise TS3QueryException(
ts3API.TS3Connection.TS3QueryException: Query failed with id=768 msg=invalid channelID
Exception ignored in: <function Ts3Bot.__del__ at 0x7ff3cba1bc10>
Traceback (most recent call last):
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 171, in __del__
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 619, in quit
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 152, in _send
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/SSHConnWrapper.py", line 86, in write
TypeError: 'NoneType' object is not callable
```

After:
```shell
(venv) root@6e1d21c4400e:/teamspeak3-python-bot# ./main.py
Failed to find the default channel `doesNotExist`.
Error on setting up client
Traceback (most recent call last):
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 148, in setup_bot
    raise query_exception
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 143, in setup_bot
    self.channel = self.get_channel_id(self.default_channel)
  File "/teamspeak3-python-bot/teamspeak_bot.py", line 55, in get_channel_id
    ret = self.ts3conn.channelfind(pattern=name)
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 440, in channelfind
    self._send("channelfind", ["pattern=" + pattern]))
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 167, in _send
    raise TS3QueryException(
ts3API.TS3Connection.TS3QueryException: Query failed with id=768 msg=invalid channelID
```