### PR TITLE
Fix non-working newlines in `channel_description`

### DIFF
--- a/modules/channel_manager/main.py
+++ b/modules/channel_manager/main.py
@@ -260,6 +260,16 @@ class ChannelManager(Thread):
             channel_permissions = []
             for key, value in channel_config.items():
                 if key.startswith("channel_"):
+                    if key == "channel_description":
+                        # if the description contains e.g. newline sequences, they are double-escaped due to
+                        # the `deepcopy()` in the channel parser function. This corrects this again.
+                        value = (
+                            value.encode()
+                            .decode("unicode-escape")
+                            .encode("iso-8859-1")
+                            .decode("utf-8")
+                        )
+
                     channel_properties.append(f"{key}={value}")
                 else:
                     channel_permissions.append({f"{key}": value})
@@ -490,6 +500,16 @@ class ChannelManager(Thread):
         channel_permissions = []
         for key, value in channel_config.items():
             if key.startswith("channel_"):
+                if key == "channel_description":
+                    # if the description contains e.g. newline sequences, they are double-escaped due to
+                    # the `deepcopy()` in the channel parser function. This corrects this again.
+                    value = (
+                        value.encode()
+                        .decode("unicode-escape")
+                        .encode("iso-8859-1")
+                        .decode("utf-8")
+                    )
+
                 channel_properties.append(f"{key}={value}")
             else:
                 channel_permissions.append({f"{key}": value})

--- a/modules/channel_requester/main.py
+++ b/modules/channel_requester/main.py
@@ -390,6 +390,16 @@ class ChannelRequester(Thread):
                 continue
 
             if key.startswith("channel_"):
+                if key == "channel_description":
+                    # if the description contains e.g. newline sequences, they are double-escaped due to
+                    # the `deepcopy()` in the channel parser function. This corrects this again.
+                    value = (
+                        value.encode()
+                        .decode("unicode-escape")
+                        .encode("iso-8859-1")
+                        .decode("utf-8")
+                    )
+
                 channel_properties.append(f"{key}={value}")
             else:
                 channel_permissions.append({f"{key}": value})


### PR DESCRIPTION
The following config...
```
some_channel.channel_description: Let's play\r\na game together!
```

...was visible as this in the respective channel description on TeamSpeak:
```
Let's play\r\na game together!
```

With this fix, it's now visible as it should be:
```
Let's play
a game together!
```

The newline is properly formatted.