### PR TITLE
`idle_mover`: Fix `invalid clientID` error

### DIFF
--- a/modules/idle_mover/main.py
+++ b/modules/idle_mover/main.py
@@ -691,7 +691,7 @@ def client_left(event_data):
     """
     # Forget clients that were moved to the afk channel and then left
     if PLUGIN_INFO is not None:
-        if str(event_data.client_id) in PLUGIN_INFO.idling_clients:
+        if int(event_data.client_id) in PLUGIN_INFO.idling_clients:
             del PLUGIN_INFO.idling_clients[int(event_data.client_id)]
 
 


### PR DESCRIPTION
When a client got moved to the AFK channel by the bot / plugin, the client has been added to the "idle list".

When the client then left the server or were kicked / banned from the server while the client was still in the AFK channel (still idling), the function to remove the client from tidle list failed as it was searching for the client ID as string, but it's saved as integer. So the idle list contained idling clients, which already left the server.

This caused the below error in the logs and also caused the plugin to stop moving further / new idling clients to the AFK channel:
```shell
2023-02-15 22:23:46,593: DEBUG: get_back_list checking client clid=3144
2023-02-15 22:23:46,660: ERROR: Failed to get the client info of clid=3144.
Traceback (most recent call last):
  File "/teamspeak3-python-bot/modules/idle_mover/main.py", line 364, in get_back_list
    client_info = self.ts3conn.clientinfo(client_clid)
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 520, in clientinfo
    return self._parse_resp_to_dict(self._send("clientinfo", ["clid=" + str(client_id)]))
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 167, in _send
    raise TS3QueryException(
ts3API.TS3Connection.TS3QueryException: Query failed with id=512 msg=invalid clientID
2023-02-15 22:23:46,660: ERROR: Uncaught exception: <class 'ts3API.TS3Connection.TS3QueryException'>
2023-02-15 22:23:46,660: ERROR: Query failed with id=512 msg=invalid clientID
2023-02-15 22:23:46,660: ERROR: Traceback (most recent call last):
  File "/teamspeak3-python-bot/modules/idle_mover/main.py", line 624, in auto_move_all
    self.move_all_back()
  File "/teamspeak3-python-bot/modules/idle_mover/main.py", line 515, in move_all_back
    back_list = self.get_back_list()
  File "/teamspeak3-python-bot/modules/idle_mover/main.py", line 364, in get_back_list
    client_info = self.ts3conn.clientinfo(client_clid)
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 520, in clientinfo
    return self._parse_resp_to_dict(self._send("clientinfo", ["clid=" + str(client_id)]))
  File "/teamspeak3-python-bot/venv/lib/python3.9/site-packages/ts3API/TS3Connection.py", line 167, in _send
    raise TS3QueryException(
ts3API.TS3Connection.TS3QueryException: Query failed with id=512 msg=invalid clientID
```