### PR TITLE
inform_team_about_newbie: Ignore ServerQuery clients

### DIFF
--- a/modules/inform_team_about_newbie/main.py
+++ b/modules/inform_team_about_newbie/main.py
@@ -366,6 +366,14 @@ class InformTeamAboutNewbie(Thread):
             )
             return
 
+        if client.client_uid == "ServerQuery":
+            InformTeamAboutNewbie.logger.debug(
+                "The client client_name=%s, client_database_id=%s is a ServerQuery. Ignoring.",
+                int(client.client_name),
+                int(client.client_dbid),
+            )
+            return
+
         client_servergroup_ids = self.get_servergroups_by_client(client.client_dbid)
 
         if self.newbie_servergroup.get("sgid") not in client_servergroup_ids:


### PR DESCRIPTION
When you allow and configure for example TSViewer.com to regulary scan your TeamSpeak server, their clients connects every 2-5 minutes in order to fetch the current information.

However, this client is a ServerQuery user and should not poke the team about a newbie.

Thus this change introduces a change, which filters ServerQuery clients out in general.