### PR TITLE
Fix pip install deprecation

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -45,6 +45,10 @@ source venv/bin/activate
 ```
 
 ```shell
+pip3 install wheel
+```
+
+```shell
 pip3 install -r requirements.txt
 ```
 

--- a/prepare_python_venv.sh
+++ b/prepare_python_venv.sh
@@ -17,6 +17,9 @@ else
     exit 1
 fi
 
+# The `wheel` package needs to be installed before all other dependencies:
+# https://stackoverflow.com/questions/74436681/deprecation-error-wheel-package-is-not-installed
+pip install --quiet wheel
 pip install --quiet -r requirements.txt
 
 if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Fixes the deprecation "DEPRECATION: blinker is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change.".